### PR TITLE
Add global hotkey support to popup/popdown main window

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 'use strict';
 const electron = require('electron');
 const app = electron.app;  // Module to control application life.
+const globalShortcut = electron.globalShortcut; // Shortcut
 const BrowserWindow = electron.BrowserWindow;  // Module to create native browser window.
 
 const Menu = electron.Menu;
@@ -60,11 +61,41 @@ app.on('window-all-closed', function() {
   }
 });
 
+
+function preserve_geometry(window) {
+    var geom = window.getBounds();
+    window['preserved'] = geom;
+}
+
+function popup_show(window) {
+    // restore preserced position and dimension.
+    var geom = window['preserved'];
+    window.setBounds( {x: geom['x'], y: geom['y'], width: geom['width'], height: geom['height'] } );
+}
+
+function half_hide(window) {
+    // preserve current position and dimension.
+    preserve_geometry(window);
+    // set position and dimension to minimize.
+    var scr = electron.screen;
+    var sg  = scr.getPrimaryDisplay().workAreaSize;
+    window.setBounds( {x: 0, y: sg.height - 24, width: 256, height: 48}, false )
+}
+
 app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 300, height: 200});
   mainWindow.setAlwaysOnTop(true);
   mainWindow.loadURL('file://' + __dirname + '/index.html');
   //mainWindow.webContents.openDevTools();
+    app.dock.hide();
+    preserve_geometry(mainWindow);
+    globalShortcut.register('Cmd+Ctrl+f', function() {
+	app.focus();
+	popup_show(mainWindow);
+    });
+  mainWindow.on('blur', function() {
+      half_hide(mainWindow);
+  });
   mainWindow.on('closed', function() {
     mainWindow = null;
   });

--- a/script.js
+++ b/script.js
@@ -18,7 +18,8 @@ var myCodeMirror = CodeMirror.fromTextArea(document.getElementById("editor"), {
   mode: 'gfm',
   lineNumbers: true,
   theme: 'monokai',
-  lineWrapping: true
+  lineWrapping: true,
+  autofocus: true
 });
 
 require('electron').ipcRenderer.on('Send', function(event, message) {


### PR DESCRIPTION
フルサイズで表示されたままだと画面がもったいないので，
- フォーカスが外れたら小さく畳む
  - 小さく畳まれた状態でも一行分のスペースが確保されているので一言くらいなら書ける
- Cmd+Ctl+F でいつでも書ける状態に復帰する
  - リサイズや移動を覚えていて，その状態に復帰する

ようにしてみました．
